### PR TITLE
Implement CLI arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,15 +36,15 @@ find_package(OpenCV REQUIRED COMPONENTS core imgproc highgui videoio)
 find_package(cpr REQUIRED)
 find_package(Threads REQUIRED)
 
-add_library(Sakura STATIC
+add_library(SakuraLib STATIC
   sakura.cpp
 )
 
-target_include_directories(Sakura PUBLIC
+target_include_directories(SakuraLib PUBLIC
   ${OpenCV_INCLUDE_DIRS}
 )
 
-target_link_libraries(Sakura PRIVATE
+target_link_libraries(SakuraLib PRIVATE
   cpr::cpr
   ${OpenCV_LIBS}
   SIXEL::sixel
@@ -61,7 +61,7 @@ target_include_directories(sakura PRIVATE
 )
 
 target_link_libraries(sakura PRIVATE
-  Sakura
+  SakuraLib
   ${OpenCV_LIBS}
   SIXEL::sixel
   Threads::Threads

--- a/example.cpp
+++ b/example.cpp
@@ -69,11 +69,29 @@ bool process_image(std::string url) {
   return sakura.renderFromMat(img, options);
 }
 
+bool process_gif(std::string url) {
+  Sakura sakura;
+  bool stat = false;
+  auto [termPixW, termPixH] = getTerminalPixelSize();
+
+  // For GIF, we'll let the sakura library handle sizing internally
+  // but still set reasonable defaults
+  Sakura::RenderOptions options;
+  options.mode = Sakura::SIXEL;
+  options.dither = Sakura::FLOYD_STEINBERG;
+  options.terminalAspectRatio = 1.0;
+  options.width = termPixW;
+  options.height = termPixH;
+
+  return sakura.renderGifFromUrl(url, options);
+}
+
 int main(int argc, char **argv) {
   // Parse command line arguments
   static struct option long_options[] = {
       {"help",        no_argument,       0, 'h'},
       {"image",       required_argument, 0, 'i'},
+      {"gif",         required_argument, 0, 'g'},
       {0, 0, 0, 0}
   };
   
@@ -83,17 +101,23 @@ int main(int argc, char **argv) {
   int opt;
   int option_index = 0;
 
-  while ((opt = getopt_long(argc, argv, "hv:i:", long_options, &option_index)) != -1) {
+  while ((opt = getopt_long(argc, argv, "hv:i:g:", long_options, &option_index)) != -1) {
 		switch (opt) {
 			case 'h':
 				std::cout << "Usage: program [options]\n"
                   << "Options:\n"
                   << "  -h, --help         Show help message\n"
-                  << "  -i, --image <path> Process image file\n";
+                  << "  -i, --image <path> Process image file\n"
+                  << "  -g, --gif <path>   Process GIF file\n"
+        ;
 				return 0;
         				
       case 'i':
         process_image( optarg );
+        break;
+      
+      case 'g':
+        process_gif( optarg );
         break;
 				
 			case '?':
@@ -144,16 +168,7 @@ int main(int argc, char **argv) {
     std::cout << "Enter GIF URL: ";
     std::cin >> gifUrl;
     std::cout << "Rendering GIF...\n";
-    // For GIF, we'll let the sakura library handle sizing internally
-    // but still set reasonable defaults
-    Sakura::RenderOptions options;
-    options.mode = Sakura::SIXEL;
-    options.dither = Sakura::FLOYD_STEINBERG;
-    options.terminalAspectRatio = 1.0;
-    options.width = termPixW;
-    options.height = termPixH;
-
-    stat = sakura.renderGifFromUrl(gifUrl, options);
+    stat = process_gif(gifUrl);
     break;
   }
   case 3: {

--- a/example.cpp
+++ b/example.cpp
@@ -103,6 +103,24 @@ bool process_video(std::string url) {
   return sakura.renderVideoFromUrl(url, options);
 }
 
+bool process_local_video(std::string path) {
+  Sakura sakura;
+  bool stat = false;
+  auto [termPixW, termPixH] = getTerminalPixelSize();
+
+  // For video, we'll let the sakura library handle sizing internally
+  // but still set reasonable defaults
+  Sakura::RenderOptions options;
+  options.mode = Sakura::SIXEL;
+  options.dither = Sakura::FLOYD_STEINBERG;
+  options.terminalAspectRatio = 1.0;
+  options.width = termPixW;
+  options.height = termPixH;
+
+  stat = sakura.renderVideoFromFile(path, options);
+  return stat;
+}
+
 int main(int argc, char **argv) {
   // Parse command line arguments
   static struct option long_options[] = {
@@ -119,15 +137,16 @@ int main(int argc, char **argv) {
   int opt;
   int option_index = 0;
 
-  while ((opt = getopt_long(argc, argv, "hv:i:g:", long_options, &option_index)) != -1) {
+  while ((opt = getopt_long(argc, argv, "hv:i:g:l:", long_options, &option_index)) != -1) {
 		switch (opt) {
 			case 'h':
 				std::cout << "Usage: sakura [options]\n"
                   << "Options:\n"
-                  << "  -h, --help           Show help message\n"
-                  << "  -i, --image <path>   Process image file\n"
-                  << "  -g, --gif <path>     Process GIF file\n"
-                  << "  -v, --video <path>   Process video file\n"
+                  << "  -h, --help                 Show help message\n"
+                  << "  -i, --image <path>         Process image file\n"
+                  << "  -g, --gif <path>           Process GIF file\n"
+                  << "  -v, --video <path>         Process video file\n"
+                  << "  -l, --local-video <path>   Process local video file\n"
         ;
 				return 0;
         				
@@ -141,6 +160,10 @@ int main(int argc, char **argv) {
       
       case 'v':
 				process_video( optarg );
+				break;
+      
+      case 'l':
+				process_local_video( optarg );
 				break;
 				
 			case '?':
@@ -206,14 +229,7 @@ int main(int argc, char **argv) {
     std::cin >> localVideoPath;
     std::cout << "Rendering video from file (with audio)...\n";
 
-    Sakura::RenderOptions options;
-    options.mode = Sakura::SIXEL;
-    options.dither = Sakura::FLOYD_STEINBERG;
-    options.terminalAspectRatio = 1.0;
-    options.width = termPixW;
-    options.height = termPixH;
-
-    stat = sakura.renderVideoFromFile(localVideoPath, options);
+    stat = process_local_video(localVideoPath);
     break;
   }
   default: {

--- a/example.cpp
+++ b/example.cpp
@@ -128,6 +128,7 @@ int main(int argc, char **argv) {
       {"image",       required_argument, 0, 'i'},
       {"gif",         required_argument, 0, 'g'},
       {"video",       required_argument, 0, 'v'},
+      {"local-video", required_argument, 0, 'l'},
       {0, 0, 0, 0}
   };
   

--- a/example.cpp
+++ b/example.cpp
@@ -136,55 +136,57 @@ int main(int argc, char **argv) {
   
   int opt;
   int option_index = 0;
+  bool stat = false;
 
-  while ((opt = getopt_long(argc, argv, "hv:i:g:l:", long_options, &option_index)) != -1) {
-		switch (opt) {
-			case 'h':
-				std::cout << "Usage: sakura [options]\n"
-                  << "Options:\n"
-                  << "  -h, --help                 Show help message\n"
-                  << "  -i, --image <path>         Process image file\n"
-                  << "  -g, --gif <path>           Process GIF file\n"
-                  << "  -v, --video <path>         Process video file\n"
-                  << "  -l, --local-video <path>   Process local video file\n"
-        ;
-				return 0;
-        				
-      case 'i':
-        process_image( optarg );
-        break;
-      
-      case 'g':
-        process_gif( optarg );
-        break;
-      
-      case 'v':
-				process_video( optarg );
-				break;
-      
-      case 'l':
-				process_local_video( optarg );
-				break;
-				
-			case '?':
-				// getopt_long automatically prints error message
-				return 1;
-				
-			default:
-				std::cerr << "Unknown option: " << opt << std::endl;
-				return 1;
-		}
-	}
+  if (argc > 1) {
+    while ((opt = getopt_long(argc, argv, "hv:i:g:l:", long_options, &option_index)) != -1) {
+      switch (opt) {
+        case 'h':
+          std::cout << "Usage: sakura [options]\n"
+                    << "Options:\n"
+                    << "  -h, --help                 Show help message\n"
+                    << "  -i, --image <path>         Process image file\n"
+                    << "  -g, --gif <path>           Process GIF file\n"
+                    << "  -v, --video <path>         Process video file\n"
+                    << "  -l, --local-video <path>   Process local video file\n"
+          ;
+          return 0;
+                  
+        case 'i':
+          stat = process_image( optarg );
+          break;
+        
+        case 'g':
+          stat = process_gif( optarg );
+          break;
+        
+        case 'v':
+          stat = process_video( optarg );
+          break;
+        
+        case 'l':
+          stat = process_local_video( optarg );
+          break;
+          
+        case '?':
+          // getopt_long automatically prints error message
+          return 1;
+          
+        default:
+          std::cerr << "Unknown option: " << opt << std::endl;
+          return 1;
+      }
+    }
+    if (!stat) {
+      std::cerr << "Failed to render content\n";
+    }
+    return 0;
+  }
 	
 	// Handle any remaining non-option arguments
 	for (int i = optind; i < argc; i++) {
 		std::cout << "Non-option argument: " << argv[i] << std::endl;
 	}
-
-  if (argc > 1) {
-    // Return here as we have done via cli
-    return 0;
-  }
 
   // Continue to existing interactive mode
   Sakura sakura;
@@ -201,7 +203,6 @@ int main(int argc, char **argv) {
   int choice;
   std::cin >> choice;
 
-  bool stat = false;
   switch (choice) {
   case 1: {
     std::cout << "Enter image URL: ";

--- a/example.cpp
+++ b/example.cpp
@@ -86,12 +86,30 @@ bool process_gif(std::string url) {
   return sakura.renderGifFromUrl(url, options);
 }
 
+bool process_video(std::string url) {
+  Sakura sakura;
+  bool stat = false;
+  auto [termPixW, termPixH] = getTerminalPixelSize();
+
+  // For video, we'll let the sakura library handle sizing internally
+  // but still set reasonable defaults
+  Sakura::RenderOptions options;
+  options.mode = Sakura::SIXEL;
+  options.dither = Sakura::FLOYD_STEINBERG;
+  options.terminalAspectRatio = 1.0;
+  options.width = termPixW;
+  options.height = termPixH;
+
+  return sakura.renderVideoFromUrl(url, options);
+}
+
 int main(int argc, char **argv) {
   // Parse command line arguments
   static struct option long_options[] = {
       {"help",        no_argument,       0, 'h'},
       {"image",       required_argument, 0, 'i'},
       {"gif",         required_argument, 0, 'g'},
+      {"video",       required_argument, 0, 'v'},
       {0, 0, 0, 0}
   };
   
@@ -104,11 +122,12 @@ int main(int argc, char **argv) {
   while ((opt = getopt_long(argc, argv, "hv:i:g:", long_options, &option_index)) != -1) {
 		switch (opt) {
 			case 'h':
-				std::cout << "Usage: program [options]\n"
+				std::cout << "Usage: sakura [options]\n"
                   << "Options:\n"
-                  << "  -h, --help         Show help message\n"
-                  << "  -i, --image <path> Process image file\n"
-                  << "  -g, --gif <path>   Process GIF file\n"
+                  << "  -h, --help           Show help message\n"
+                  << "  -i, --image <path>   Process image file\n"
+                  << "  -g, --gif <path>     Process GIF file\n"
+                  << "  -v, --video <path>   Process video file\n"
         ;
 				return 0;
         				
@@ -119,6 +138,10 @@ int main(int argc, char **argv) {
       case 'g':
         process_gif( optarg );
         break;
+      
+      case 'v':
+				process_video( optarg );
+				break;
 				
 			case '?':
 				// getopt_long automatically prints error message
@@ -175,14 +198,7 @@ int main(int argc, char **argv) {
     std::cout << "Enter video URL: ";
     std::cin >> videoUrl;
     std::cout << "Rendering video from URL (with audio)...\n";
-    Sakura::RenderOptions options;
-    options.mode = Sakura::SIXEL;
-    options.dither = Sakura::FLOYD_STEINBERG;
-    options.terminalAspectRatio = 1.0;
-    options.width = termPixW;
-    options.height = termPixH;
-
-    stat = sakura.renderVideoFromUrl(videoUrl, options);
+    stat = process_video(videoUrl);
     break;
   }
   case 4: {


### PR DESCRIPTION
Adds command line arguments that replicate the interactive actions
Also moves the actual processing into functions to prevent duplication

Usage:
```
╰─❯ ./sakura -h
Usage: sakura [options]
Options:
  -h, --help                 Show help message
  -i, --image <path>         Process image file
  -g, --gif <path>           Process GIF file
  -v, --video <path>         Process video file
  -l, --local-video <path>   Process local video file
```

I can still see some areas of code that could easily be de-duplicated
Potential feature suggestion to detect appropriate action based on file extension/url instead of manual specification

NB: I haven't written C++ in ~20 years so I have no idea if what I've done was the best way to implement this - however, it works (tested on macOS 26 w/ iTerm2)